### PR TITLE
Fix fallback to stdin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grabinput"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["J/A <archer884@gmail.com>"]
 exclude = ["examples/*"]
 description = "Unixy lib for reading from a file or from stdin"
@@ -10,4 +10,4 @@ license = "MIT/Apache-2.0"
 keywords = ["stdin", "file", "read", "input", "simple"]
 
 [dependencies]
-clippy = {version = "0.0.90", optional = true}
+clippy = {version = "0.0", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub use stdin::FromStdin;
 pub fn from_args() -> FromFile {
     std::env::args()
         .nth(1)
-        .map(|path| FromFile::from_path(path))
-        .unwrap_or_else(|| FromFile::new())
+        .map(FromFile::from_path)
+        .unwrap_or_else(FromFile::new)
 }
 
 /// Creates an input handle based on the provided path.


### PR DESCRIPTION
A bug prevented fallback to stdin from ever producing any output unless some portion of the fallback iterator had been consumed first. This PR will resolve that bug by creating a new handle for stdin and consuming that in the event that one has not yet been created.

This PR will also update clippy lints because those are broken too on the nightly.